### PR TITLE
fix: avoid possible memory leaks v1.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-inject",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Minimalistic dependency injection implementation",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
- Fix circular references in DIProxyBuilder by using empty object instead of 'this'
- Replace Symbol.for() with regular Symbol() to prevent global registry pollution
- Add removeSubModule() method for granular sub-module management
- Add dispose() method to DIProxyBuilder for manual cleanup
- Bump version from 1.10.0 to 1.10.1 (patch release)

These changes prevent memory leaks in long-running applications while maintaining full backward compatibility.