### PR TITLE
feat: v1.12.0 — fork, unbind, eager binding, dispose lifecycle & dependency graph analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,118 @@ di.get('A'); // Throws 'No binding for injectable "A"'
 di.get(Symbol.for('A')); // Throws 'No binding for injectable "A"'
 ````
 
+### Dependency Graph Analyzer
+
+`mini-inject` can generate a dependency graph for any DI module so you can understand the full dependency tree, spot potential optimisations, and detect circular dependencies before they cause problems at runtime.
+
+#### Programmatic API
+
+```javascript
+const {DI} = require('mini-inject');
+
+class AuthService {}
+class UserService {}
+class OrderService {}
+class NotificationService {}
+
+const di = new DI();
+di.bind(AuthService, []);
+di.bind(UserService, [AuthService]);
+di.bind(OrderService, [UserService, AuthService]);
+di.bind(NotificationService, () => new NotificationService()); // custom factory
+
+// Get a serialisable graph object
+const graph = di.getDependencyGraph();
+// { nodes: [...], edges: [...], cycles: [] }
+console.log(JSON.stringify(graph, null, 2));
+
+// Or get a formatted text report (header is shown by default)
+console.log(di.formatDependencyGraph());
+// mini-inject dependency graph — 4 binding(s), 0 cycle(s)
+// ═══════════════════════════════════════════════════════
+//
+// AuthService           [singleton]
+// UserService           [singleton]               AuthService
+// OrderService          [singleton]               UserService, AuthService
+// NotificationService   [singleton]               (custom initializer - unknown deps)
+
+// Without the header/summary section
+console.log(di.formatDependencyGraph({header: false}));
+
+// Static variants accept a pre-computed graph
+const graph2 = DI.getDependencyGraph(di);
+const text2  = DI.formatDependencyGraph(graph2, {header: false});
+```
+
+Circular dependencies are detected and reported without throwing — they are valid when resolved via `lateResolve: true` or `autoResolveCircularDependencies`:
+
+```javascript
+class A {}
+class B {}
+
+const di = new DI();
+di.bind(A, [B]);
+di.bind(B, [A], {lateResolve: true});
+
+console.log(di.formatDependencyGraph());
+// mini-inject dependency graph — 2 binding(s), 1 cycle(s)
+// ══════════════════════════════════════════════════════
+//
+// A   [singleton]               B  ⚠ CYCLE: A → B → A
+// B   [singleton]  lateResolve  A  ⚠ CYCLE: A → B → A
+//
+// Cycles detected:
+//   [1] A → B → A
+```
+
+The `nodes` array describes each binding:
+
+| Field | Type | Description |
+|---|---|---|
+| `key` | `string` | Display name (`"MyClass"`, `"myKey"`, `"Token<desc>"`) |
+| `isSingleton` | `boolean` | Whether the binding is a singleton |
+| `lateResolve` | `boolean` | Whether `lateResolve: true` is set on this binding |
+| `isSubModule` | `boolean` | `true` when the binding comes from an attached sub-module |
+| `deps` | `DepDescriptor[] \| null` | Dep list, or `null` when a custom factory function was used |
+
+Each `DepDescriptor` is one of:
+- `{ type: 'injectable', key: string }` — another registered injectable
+- `{ type: 'literal', value: unknown }` — a `DI.literal(...)` value
+- `{ type: 'factory', name: string | null }` — a `DI.factory(...)` function (anonymous when `name` is `null`)
+
+#### CLI
+
+```bash
+npx mini-inject analyze <path-to-file>
+```
+
+The file must export a `DI` instance — either as `export default di` (ESM), `module.exports = di` (CJS), or as a named export.
+
+```bash
+# Default: text format with header
+npx mini-inject analyze ./src/container.js
+
+# JSON output (pipe-friendly)
+npx mini-inject analyze ./src/container.js --format=json
+
+# Plain rows, no title or cycles summary
+npx mini-inject analyze ./src/container.js --no-header
+
+# When multiple DI instances are exported, pick one by name
+npx mini-inject analyze ./src/container.js --export=appDI
+```
+
 ## Changelog
+
+#### 1.12.0
+
+* Added `di.getDependencyGraph()` / `DI.getDependencyGraph(di)` — returns a serialisable graph object (`{ nodes, edges, cycles }`) describing all registered bindings, their dependency descriptors, directed edges, and any detected circular-dependency cycles
+* Added `di.formatDependencyGraph(opts?)` / `DI.formatDependencyGraph(graph, opts?)` — renders a dependency graph as a human-readable text report; pass `{ header: false }` to suppress the title and cycles-summary section
+* Added `bin/analyze.mjs` CLI — run `npx mini-inject analyze <file>` to print a dependency report for any module that exports a `DI` instance; supports `--format=text|json`, `--export=<name>`, and `--no-header`
+* Dep descriptors distinguish between `injectable` keys, `Literal<value>`, `Factory<name>`, and `null` (custom factory function — deps cannot be statically determined)
+* Token keys are displayed as `Token<description>` in all outputs
+* Bindings from attached sub-modules are included in the graph and marked with `isSubModule: true`
+* New TypeScript types: `DepDescriptor`, `GraphNode`, `GraphEdge`, `DependencyGraph`, `FormatGraphOptions`
 
 #### 1.11.0
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,9 @@ npx mini-inject analyze ./src/container.js --export=appDI
 
 #### 1.12.0
 
+* Added `di.unbind(injectable)` — removes a single binding and its cached singleton instance; calls `dispose()` on the instance if the method exists, then removes both the binding and the cached value
+* Added `{ eager: true }` option to `bind()` — when set on a singleton binding, the instance is created immediately at bind time instead of lazily on first `get()`; silently ignored for transient bindings
+* `clear()` now calls `dispose()` on every cached singleton instance (and on sub-module instances recursively) before wiping the container, giving services a chance to release resources; errors thrown by `dispose()` are silently ignored
 * Added `di.getDependencyGraph()` / `DI.getDependencyGraph(di)` — returns a serialisable graph object (`{ nodes, edges, cycles }`) describing all registered bindings, their dependency descriptors, directed edges, and any detected circular-dependency cycles
 * Added `di.formatDependencyGraph(opts?)` / `DI.formatDependencyGraph(graph, opts?)` — renders a dependency graph as a human-readable text report; pass `{ header: false }` to suppress the title and cycles-summary section
 * Added `bin/analyze.mjs` CLI — run `npx mini-inject analyze <file>` to print a dependency report for any module that exports a `DI` instance; supports `--format=text|json`, `--export=<name>`, and `--no-header`

--- a/README.md
+++ b/README.md
@@ -374,6 +374,87 @@ sub2.bind(A);
 sub2.get(Sub2D); // Sub2D
 ```
 
+### Forking (Scoped Containers)
+
+`di.fork()` creates a child `DI` instance that inherits all of its parent's bindings while keeping its own isolated scope.
+
+Resolution priority inside a fork:
+1. The fork's own local bindings
+2. The fork's sub-modules
+3. The parent (transparently, up the chain)
+
+Parent singletons are **shared** — resolving a parent-bound singleton from a fork returns the same cached instance that the parent holds. Local fork bindings never affect the parent.
+
+This is the primary pattern for per-request scoping in servers, or for test isolation where you want to override a handful of bindings without rebuilding the full container:
+
+```javascript
+const {DI} = require('mini-inject');
+
+class DbPool {
+    query(sql) { return `result of: ${sql}`; }
+}
+class UserRepo {
+    constructor(db) { this.db = db; }
+    findUser(id) { return this.db.query(`SELECT * FROM users WHERE id=${id}`); }
+}
+class RequestContext {
+    constructor(req) { this.userId = req.headers['x-user-id']; }
+}
+class OrderService {
+    constructor(userRepo, ctx) {
+        this.userRepo = userRepo;
+        this.ctx = ctx;
+    }
+    currentUserOrders() { return this.userRepo.findUser(this.ctx.userId); }
+}
+
+// Application-level container — set up once at startup
+const appDI = new DI();
+appDI.bind(DbPool, []);
+appDI.bind(UserRepo, [DbPool]);
+
+// Per-request fork — created and cleared on every request
+const req = {headers: {'x-user-id': '42'}};
+const reqDI = appDI.fork();
+reqDI.bind(RequestContext, () => new RequestContext(req));
+reqDI.bind(OrderService, [UserRepo, RequestContext]);
+
+const svc = reqDI.get(OrderService);
+console.log(svc.currentUserOrders()); // result of: SELECT * FROM users WHERE id=42
+
+// DbPool and UserRepo are shared — same instances as in appDI
+console.log(reqDI.get(DbPool) === appDI.get(DbPool)); // true
+
+// End of request — disposes only the fork's local singletons; appDI is untouched
+reqDI.clear();
+console.log(appDI.has(DbPool)); // true
+```
+
+Forks can also be used to isolate tests without rebuilding the entire application container:
+
+```javascript
+// production container
+const appDI = new DI();
+appDI.bind(DbPool, []);
+appDI.bind(UserRepo, [DbPool]);
+appDI.bind(OrderService, [UserRepo]);
+
+// test — replace only what needs to change
+const testDI = appDI.fork();
+testDI.bind(DbPool, () => new FakeDbPool()); // override
+
+const svc = testDI.get(OrderService); // OrderService → UserRepo → FakeDbPool
+```
+
+Forks can be nested as deep as needed:
+
+```javascript
+const rootDI  = new DI();   // global singletons
+const scopeDI = rootDI.fork();  // request scope
+const childDI = scopeDI.fork(); // sub-scope (e.g. a transaction)
+// childDI sees all of scopeDI's and rootDI's bindings
+```
+
 ### Tokens
 
 The Token is an alternative when the developer wants more control for how the binding keys are generated.
@@ -541,6 +622,7 @@ npx mini-inject analyze ./src/container.js --export=appDI
 
 #### 1.12.0
 
+* Added `di.fork()` — creates a child `DI` instance that delegates unresolved keys to its parent; parent singletons are shared, fork-local bindings stay isolated, and `clear()` on the fork never touches the parent. Supports arbitrary fork depth
 * Added `di.unbind(injectable)` — removes a single binding and its cached singleton instance; calls `dispose()` on the instance if the method exists, then removes both the binding and the cached value
 * Added `{ eager: true }` option to `bind()` — when set on a singleton binding, the instance is created immediately at bind time instead of lazily on first `get()`; silently ignored for transient bindings
 * `clear()` now calls `dispose()` on every cached singleton instance (and on sub-module instances recursively) before wiping the container, giving services a chance to release resources; errors thrown by `dispose()` are silently ignored

--- a/bin/analyze.mjs
+++ b/bin/analyze.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import {pathToFileURL} from 'url';
+import {resolve} from 'path';
+
+// ─── Argument parsing ─────────────────────────────────────────────────────────
+
+const rawArgs = process.argv.slice(2);
+const [command, filePath, ...rest] = rawArgs;
+
+if (command !== 'analyze' || !filePath) {
+    console.error(
+        'Usage: mini-inject analyze <file> [--format=text|json] [--export=<name>] [--no-header]',
+    );
+    process.exit(1);
+}
+
+const flags = Object.fromEntries(
+    rest
+        .filter((a) => a.startsWith('--'))
+        .map((a) => {
+            const eq = a.indexOf('=');
+            if (eq === -1) return [a.slice(2), true];
+            return [a.slice(2, eq), a.slice(eq + 1)];
+        }),
+);
+
+const format = flags.format || 'text';
+const exportName = flags.export || null;
+const header = !flags['no-header'];
+
+if (format !== 'text' && format !== 'json') {
+    console.error(`Unknown format "${format}". Use --format=text or --format=json.`);
+    process.exit(1);
+}
+
+// ─── Load the user module ─────────────────────────────────────────────────────
+
+const absolutePath = resolve(process.cwd(), filePath);
+const fileUrl = pathToFileURL(absolutePath).href;
+
+let mod;
+try {
+    mod = await import(fileUrl);
+} catch (err) {
+    console.error(`Failed to import "${filePath}": ${err.message}`);
+    process.exit(1);
+}
+
+// ─── Locate the DI instance ───────────────────────────────────────────────────
+
+function isDI(obj) {
+    return (
+        obj != null &&
+        typeof obj === 'object' &&
+        typeof obj.getDependencyGraph === 'function' &&
+        typeof obj.formatDependencyGraph === 'function'
+    );
+}
+
+function findInObject(obj) {
+    if (!obj || typeof obj !== 'object') return null;
+    for (const value of Object.values(obj)) {
+        if (isDI(value)) return value;
+    }
+    return null;
+}
+
+let di = null;
+
+if (exportName) {
+    // Explicit --export=name: check named exports, then default's properties
+    const candidate = mod[exportName] ?? (mod.default ? mod.default[exportName] : undefined);
+    if (!isDI(candidate)) {
+        console.error(`Export "${exportName}" is not a DI instance or was not found.`);
+        process.exit(1);
+    }
+    di = candidate;
+} else if (isDI(mod.default)) {
+    // ESM `export default di` or CJS `module.exports = di`
+    di = mod.default;
+} else {
+    // Scan named exports
+    di = findInObject(mod);
+    // Fallback: scan properties of the default export (e.g. CJS `module.exports = { di }`)
+    if (!di) di = findInObject(mod.default);
+}
+
+if (!di) {
+    console.error(
+        'No DI instance found in the exported module.\n' +
+        'Use --export=<name> to specify the export name, or ensure your file exports a DI instance.',
+    );
+    process.exit(1);
+}
+
+// ─── Output ───────────────────────────────────────────────────────────────────
+
+if (format === 'json') {
+    const graph = di.getDependencyGraph();
+    process.stdout.write(JSON.stringify(graph, null, 2) + '\n');
+} else {
+    process.stdout.write(di.formatDependencyGraph({header}) + '\n');
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "mini-inject",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Minimalistic dependency injection implementation",
   "type": "commonjs",
   "main": "index.js",
   "module": "index.mjs",
+  "bin": {
+    "mini-inject": "./bin/analyze.mjs"
+  },
   "files": [
     "index.js",
     "index.cjs",
@@ -12,7 +15,8 @@
     "index.d.ts",
     "index.d.mts",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "bin/"
   ],
   "exports": {
     ".": {

--- a/src/mini-inject.d.ts
+++ b/src/mini-inject.d.ts
@@ -10,6 +10,64 @@ export type Dependency =
   | DIFactory<any>;
 export type BindingFunc<T> = (di: DI) => T;
 
+// ─── Dependency graph ────────────────────────────────────────────────────────
+
+/** A single dependency descriptor inside a graph node's `deps` array. */
+export type DepDescriptor =
+  | { type: "injectable"; key: string }
+  | { type: "literal"; value: unknown }
+  | { type: "factory"; name: string | null };
+
+/**
+ * A node in the dependency graph — one per binding registered in the DI module.
+ * Nodes whose binding was declared with a custom factory function have `deps: null`
+ * because the dependencies cannot be statically determined.
+ */
+export interface GraphNode {
+  /** Human-readable display key (class name, string key, or `Token<description>`). */
+  key: string;
+  isSingleton: boolean;
+  lateResolve: boolean;
+  /** `true` when the binding originates from an attached sub-module. */
+  isSubModule: boolean;
+  /**
+   * Dependency descriptors for each position in the binding's dependency list.
+   * `null` means the binding was declared with a custom factory function and the
+   * dependencies cannot be statically determined.
+   */
+  deps: DepDescriptor[] | null;
+}
+
+/** A directed edge between two injectable nodes in the dependency graph. */
+export interface GraphEdge {
+  from: string;
+  to: string;
+  /** `true` when this edge is part of at least one circular-dependency cycle. */
+  isCircular: boolean;
+}
+
+/** Full dependency graph returned by `DI.getDependencyGraph()`. */
+export interface DependencyGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  /**
+   * Each cycle is an array of display keys where the first key is repeated at
+   * the end to make the loop explicit, e.g. `["A", "B", "A"]`.
+   */
+  cycles: string[][];
+}
+
+/** Options for `formatDependencyGraph`. */
+export interface FormatGraphOptions {
+  /**
+   * When `true` (default), a title line and a cycles summary section are
+   * included in the output. Pass `false` to get rows only.
+   */
+  header?: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
  * Describes which dependency shapes are acceptable for a single constructor parameter of type `T`.
  *
@@ -253,6 +311,9 @@ export class DILiteral<T> {
  */
 export class DIFactory<T> {
   private constructor(fn: (di: DIGetter) => T);
+
+  /** The name of the wrapped factory function, or `null` if it is anonymous. */
+  readonly name: string | null;
 
   get(di: DIGetter): T;
 }
@@ -545,6 +606,42 @@ export class DI {
    * ```
    */
   autoResolveCircularDependencies(enabled: boolean): this;
+
+  /**
+   * Build a dependency graph for this DI module (and any attached sub-modules).
+   *
+   * Bindings declared with an array of dependencies are fully described.
+   * Bindings declared with a custom factory function have `deps: null` because
+   * the dependencies cannot be statically determined at analysis time.
+   *
+   * The graph can be serialised directly with `JSON.stringify` for JSON output.
+   */
+  getDependencyGraph(): DependencyGraph;
+
+  /**
+   * Build a dependency graph for the given DI module.
+   * Convenience static wrapper around the instance method.
+   * @param di The DI instance to analyse.
+   */
+  static getDependencyGraph(di: DI): DependencyGraph;
+
+  /**
+   * Render the dependency graph of this module as a human-readable text report.
+   * @param opts Optional formatting options (e.g. `{ header: false }`).
+   */
+  formatDependencyGraph(opts?: FormatGraphOptions): string;
+
+  /**
+   * Render a pre-computed `DependencyGraph` as a human-readable text report.
+   * Useful when you have already obtained the graph object and want to format it
+   * separately — for example after enriching or filtering it.
+   * @param graph A graph previously returned by `getDependencyGraph`.
+   * @param opts Optional formatting options.
+   */
+  static formatDependencyGraph(
+    graph: DependencyGraph,
+    opts?: FormatGraphOptions,
+  ): string;
 
   /**
    * Get the binding for the injectable if available otherwise return undefined

--- a/src/mini-inject.d.ts
+++ b/src/mini-inject.d.ts
@@ -1149,6 +1149,38 @@ export class DI {
   unbind<T>(injectable: InjectableOrToken<T>): this;
 
   /**
+   * Create a fork (child scope) of this DI instance.
+   *
+   * A fork is a fresh `DI` that delegates any unresolved key upward to its parent:
+   * - Bindings registered **on the fork** are local to the fork and override the parent.
+   * - Bindings registered **on the parent** are transparently resolved through the parent,
+   *   returning the parent's cached singleton instance (so singletons are shared).
+   * - The parent is **never** affected by `clear()` or `unbind()` on the fork.
+   * - The fork can itself be forked, creating a chain of scopes.
+   *
+   * This is the primary pattern for per-request or per-test scoping:
+   *
+   * ```javascript
+   * const appDI = new DI();
+   * appDI.bind(DbPool, []);              // singleton, shared across all forks
+   * appDI.bind(UserRepo, [DbPool]);      // singleton, shared
+   *
+   * // per HTTP request:
+   * const reqDI = appDI.fork();
+   * reqDI.bind(RequestContext, () => new RequestContext(req));
+   * reqDI.bind(OrderService, [UserRepo, RequestContext]);
+   *
+   * const svc = reqDI.get(OrderService); // UserRepo resolved from parent (shared)
+   *
+   * // end of request — only the fork's local singletons are disposed:
+   * reqDI.clear();
+   * ```
+   *
+   * @returns A new `DI` instance whose parent is `this`.
+   */
+  fork(): DI;
+
+  /**
    * Add a sub-module to this. When resolving dependencies it will also search in the sub-modules.
    * Any `DI` instance can have as many sub-modules as necessary. However beware that each module can only access it own dependencies and its sub-modules.
    * A sub-module does not has access to its parent dependencies. During dependency resolution, each module always use its own bindings before trying the subModules.

--- a/src/mini-inject.d.ts
+++ b/src/mini-inject.d.ts
@@ -1015,7 +1015,7 @@ export class DI {
   bind<T extends object, Args extends readonly unknown[]>(
     injectable: (new (...args: [...Args]) => T) | Token<T>,
     dependencies: DependenciesFor<Args>,
-    opts?: { isSingleton?: boolean; lateResolve?: boolean },
+    opts?: { isSingleton?: boolean; lateResolve?: boolean; eager?: boolean },
   ): this;
   /**
    * Bind a class or another constructable object so it can be fetched later
@@ -1053,7 +1053,7 @@ export class DI {
   bind<T>(
     injectable: ClassConstructor<T> | Token<T>,
     dependencies: Dependency[],
-    opts?: { isSingleton?: boolean; lateResolve?: boolean },
+    opts?: { isSingleton?: boolean; lateResolve?: boolean; eager?: boolean },
   ): this;
   /**
    * Bind a class or another constructable object so it can be fetched later
@@ -1088,7 +1088,7 @@ export class DI {
   bind<T>(
     injectable: InjectableOrToken<T>,
     func: BindingFunc<T>,
-    opts?: { isSingleton?: boolean; lateResolve?: boolean },
+    opts?: { isSingleton?: boolean; lateResolve?: boolean; eager?: boolean },
   ): this;
   /**
    * Bind a class or another constructable object so it can be fetched later
@@ -1117,6 +1117,36 @@ export class DI {
    *
    */
   bind<T>(injectable: ClassConstructor<T> | Token<T>): this;
+
+  /**
+   * Remove the binding (and its cached singleton instance, if any) for a single injectable.
+   * If the cached instance exposes a `dispose()` method, it is called before the instance
+   * is removed from the container — giving it a chance to release resources (timers, connections, etc.).
+   * Errors thrown by `dispose()` are silently ignored.
+   *
+   * Has no effect when the injectable has no binding.
+   *
+   * @param injectable an injectable class, string key, Symbol, or Token
+   * @returns this
+   * @example
+   * ```javascript
+   * class DbConnection {
+   *   constructor() { this.open = true; }
+   *   dispose() { this.open = false; }
+   * }
+   *
+   * const di = new DI();
+   * di.bind(DbConnection, []);
+   *
+   * const conn = di.get(DbConnection);
+   * console.log(conn.open); // true
+   *
+   * di.unbind(DbConnection);
+   * console.log(conn.open);          // false  — dispose() was called
+   * console.log(di.has(DbConnection)); // false  — binding removed
+   * ```
+   */
+  unbind<T>(injectable: InjectableOrToken<T>): this;
 
   /**
    * Add a sub-module to this. When resolving dependencies it will also search in the sub-modules.
@@ -1212,6 +1242,9 @@ export class DI {
   /**
    * Clears all containers, bindings, and sub-modules from this DI instance.
    * This method also recursively clears all sub-modules.
+   * Before removing each cached singleton instance, `dispose()` is called on it if the method
+   * exists — giving services a chance to release resources (timers, connections, etc.).
+   * Errors thrown by `dispose()` are silently ignored.
    * After calling clear(), the DI instance will be in a clean state as if it was just created.
    * @returns void
    * @example

--- a/src/mini-inject.js
+++ b/src/mini-inject.js
@@ -146,11 +146,167 @@ class DIFactory {
         this.#fn = fn;
     }
 
+    get name() {
+        return this.#fn?.name || null;
+    }
+
     /** @param {DI} di */
     get(di) {
         return this.#fn(di);
     }
 }
+
+// ─── Dependency-graph helpers ────────────────────────────────────────────────
+
+/**
+ * Converts a raw binding key (string or Symbol) to a human-readable display string.
+ * Token symbols are rendered as `Token<description>`.
+ * @param {string|Symbol} key
+ * @returns {string}
+ */
+function formatKey(key) {
+    if (typeof key === 'string') return key;
+    if (typeof key === 'symbol') {
+        const desc = key.description ?? '';
+        const match = desc.match(/^__DIToken__\[\[(.+)\]\]$/);
+        if (match) return `Token<${match[1]}>`;
+        return desc || String(key);
+    }
+    return String(key);
+}
+
+/**
+ * Converts a raw dependency array (as stored in a binding) into DepDescriptor objects.
+ * @param {Array} rawDeps
+ * @returns {Array<{type:string, key?:string, value?:unknown, name?:string|null}>}
+ */
+function describeRawDeps(rawDeps) {
+    return rawDeps.map((dep) => {
+        if (dep instanceof DILiteral) return {type: 'literal', value: dep.value};
+        if (dep instanceof DIFactory) return {type: 'factory', name: dep.name};
+        return {type: 'injectable', key: formatKey(resolveKey(dep))};
+    });
+}
+
+/**
+ * DFS-based cycle detection over a directed graph described by nodes+edges.
+ * Returns an array of cycles, each cycle being an array of keys where the first
+ * key is repeated at the end: e.g. ["A","B","A"].
+ * @param {{key:string}[]} nodes
+ * @param {{from:string, to:string}[]} edges
+ * @returns {string[][]}
+ */
+function detectCycles(nodes, edges) {
+    const adj = new Map();
+    for (const node of nodes) adj.set(node.key, []);
+    for (const edge of edges) {
+        const neighbors = adj.get(edge.from);
+        if (neighbors) neighbors.push(edge.to);
+    }
+    const visited = new Set();
+    const cycles = [];
+    function dfs(key, path, inStack) {
+        if (inStack.has(key)) {
+            const start = path.indexOf(key);
+            cycles.push([...path.slice(start), key]);
+            return;
+        }
+        if (visited.has(key)) return;
+        inStack.add(key);
+        path.push(key);
+        for (const neighbor of adj.get(key) || []) {
+            dfs(neighbor, path, inStack);
+        }
+        path.pop();
+        inStack.delete(key);
+        visited.add(key);
+    }
+    for (const node of nodes) {
+        if (!visited.has(node.key)) dfs(node.key, [], new Set());
+    }
+    return cycles;
+}
+
+/**
+ * Formats a single DepDescriptor as a concise display string for text output.
+ * @param {{type:string, key?:string, value?:unknown, name?:string|null}} dep
+ * @returns {string}
+ */
+function formatDepText(dep) {
+    if (dep.type === 'injectable') return dep.key;
+    if (dep.type === 'literal') {
+        let val;
+        try {
+            val = JSON.stringify(dep.value);
+            if (val.length > 20) val = val.slice(0, 17) + '...';
+        } catch {
+            val = String(dep.value);
+        }
+        return `Literal<${val}>`;
+    }
+    if (dep.type === 'factory') {
+        return dep.name ? `Factory<${dep.name}>` : 'Factory<anonymous>';
+    }
+    return '?';
+}
+
+/**
+ * Renders a DependencyGraph as a human-readable text report.
+ * @param {{nodes:any[], edges:any[], cycles:string[][]}} graph
+ * @param {{header?:boolean}} [opts]
+ * @returns {string}
+ */
+function formatGraphText(graph, opts) {
+    const {header = true} = opts || {};
+    const lines = [];
+
+    if (header) {
+        const title = `mini-inject dependency graph — ${graph.nodes.length} binding(s), ${graph.cycles.length} cycle(s)`;
+        lines.push(title);
+        lines.push('═'.repeat(title.length));
+        lines.push('');
+    }
+
+    const maxKeyLen = Math.max(4, ...graph.nodes.map((n) => n.key.length));
+
+    // Map each node key to the first cycle string it participates in
+    const nodeToCycle = new Map();
+    for (const cycle of graph.cycles) {
+        const cycleStr = cycle.join(' → ');
+        for (const key of cycle.slice(0, -1)) {
+            if (!nodeToCycle.has(key)) nodeToCycle.set(key, cycleStr);
+        }
+    }
+
+    for (const node of graph.nodes) {
+        const keyCol = node.key.padEnd(maxKeyLen);
+        const singletonCol = node.isSingleton ? '[singleton]' : '[transient]';
+        const lateCol = node.lateResolve ? '  lateResolve' : '             ';
+        let depsCol;
+        if (node.deps === null) {
+            depsCol = '(custom initializer - unknown deps)';
+        } else if (node.deps.length === 0) {
+            depsCol = '';
+        } else {
+            depsCol = node.deps.map(formatDepText).join(', ');
+        }
+        const cycleStr = nodeToCycle.get(node.key);
+        const cycleCol = cycleStr ? `  ⚠ CYCLE: ${cycleStr}` : '';
+        lines.push(`${keyCol}  ${singletonCol}${lateCol}  ${depsCol}${cycleCol}`);
+    }
+
+    if (header && graph.cycles.length > 0) {
+        lines.push('');
+        lines.push('Cycles detected:');
+        graph.cycles.forEach((cycle, i) => {
+            lines.push(`  [${i + 1}] ${cycle.join(' → ')}`);
+        });
+    }
+
+    return lines.join('\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 class DI {
     /** @type {Map<string|Symbol, any>} */
@@ -336,6 +492,92 @@ class DI {
         };
     }
 
+    /**
+     * Build a dependency graph for this DI module (and any attached sub-modules).
+     * Bindings declared with an array of dependencies are fully described; bindings
+     * declared with a custom factory function are marked with `deps: null`.
+     * @returns {{nodes: any[], edges: any[], cycles: string[][]}}
+     */
+    getDependencyGraph() {
+        return DI.getDependencyGraph(this);
+    }
+
+    /**
+     * Build a dependency graph for the given DI module.
+     * @param {DI} di
+     * @returns {{nodes: any[], edges: any[], cycles: string[][]}}
+     */
+    static getDependencyGraph(di) {
+        const nodes = [];
+        const nodeKeySet = new Set();
+
+        function collect(diInstance, isSubModule) {
+            for (const [key, binding] of diInstance.#bindings) {
+                const displayKey = formatKey(key);
+                if (nodeKeySet.has(displayKey)) continue; // parent takes precedence
+                nodeKeySet.add(displayKey);
+                nodes.push({
+                    key: displayKey,
+                    isSingleton: binding.isSingleton,
+                    lateResolve: binding.lateResolve,
+                    isSubModule,
+                    deps: binding.rawDeps !== null ? describeRawDeps(binding.rawDeps) : null,
+                });
+            }
+            for (const sub of diInstance.#subModules) {
+                collect(sub, true);
+            }
+        }
+
+        collect(di, false);
+
+        // Build edges — only between known nodes, deduped
+        const edges = [];
+        const edgeSeen = new Set();
+        for (const node of nodes) {
+            if (!node.deps) continue;
+            for (const dep of node.deps) {
+                if (dep.type !== 'injectable') continue;
+                if (!nodeKeySet.has(dep.key)) continue;
+                const edgeKey = `${node.key}→${dep.key}`;
+                if (edgeSeen.has(edgeKey)) continue;
+                edgeSeen.add(edgeKey);
+                edges.push({from: node.key, to: dep.key, isCircular: false});
+            }
+        }
+
+        // Detect cycles then mark affected edges
+        const cycles = detectCycles(nodes, edges);
+        for (const edge of edges) {
+            edge.isCircular = cycles.some((cycle) =>
+                cycle.some(
+                    (k, i) => i < cycle.length - 1 && k === edge.from && cycle[i + 1] === edge.to,
+                ),
+            );
+        }
+
+        return {nodes, edges, cycles};
+    }
+
+    /**
+     * Render the dependency graph of this module as a human-readable text report.
+     * @param {{header?: boolean}} [opts]
+     * @returns {string}
+     */
+    formatDependencyGraph(opts) {
+        return DI.formatDependencyGraph(this.getDependencyGraph(), opts);
+    }
+
+    /**
+     * Render a pre-computed dependency graph as a human-readable text report.
+     * @param {{nodes: any[], edges: any[], cycles: string[][]}} graph
+     * @param {{header?: boolean}} [opts]
+     * @returns {string}
+     */
+    static formatDependencyGraph(graph, opts) {
+        return formatGraphText(graph, opts);
+    }
+
     bind(injectable, dep, opts) {
         const token = injectable;
         injectable = token instanceof Token ? token.value : injectable;
@@ -373,6 +615,7 @@ class DI {
             isSingleton,
             lateResolve: dependenciesArrayIsEmpty ? false : lateResolve,
             injectable,
+            rawDeps: dependencies,
         });
         return this;
     }

--- a/src/mini-inject.js
+++ b/src/mini-inject.js
@@ -203,28 +203,81 @@ function detectCycles(nodes, edges) {
         const neighbors = adj.get(edge.from);
         if (neighbors) neighbors.push(edge.to);
     }
-    const visited = new Set();
-    const cycles = [];
-    function dfs(key, path, inStack) {
-        if (inStack.has(key)) {
-            const start = path.indexOf(key);
-            cycles.push([...path.slice(start), key]);
-            return;
+
+    // Tarjan's SCC — correctly identifies all strongly-connected components
+    // regardless of traversal order, avoiding the missed-cycle bug of simple DFS.
+    const nodeIndex = new Map();
+    const lowlink = new Map();
+    const onStack = new Set();
+    const stack = [];
+    let counter = 0;
+    const sccOf = new Map(); // key → scc array (only for non-trivial SCCs)
+    const nonTrivialSccs = [];
+
+    const strongconnect = (v) => {
+        nodeIndex.set(v, counter);
+        lowlink.set(v, counter);
+        counter++;
+        stack.push(v);
+        onStack.add(v);
+        for (const w of adj.get(v) || []) {
+            if (!nodeIndex.has(w)) {
+                strongconnect(w);
+                lowlink.set(v, Math.min(lowlink.get(v), lowlink.get(w)));
+            } else if (onStack.has(w)) {
+                lowlink.set(v, Math.min(lowlink.get(v), nodeIndex.get(w)));
+            }
         }
-        if (visited.has(key)) return;
-        inStack.add(key);
-        path.push(key);
-        for (const neighbor of adj.get(key) || []) {
-            dfs(neighbor, path, inStack);
+        if (lowlink.get(v) === nodeIndex.get(v)) {
+            const scc = [];
+            let w;
+            do {
+                w = stack.pop();
+                onStack.delete(w);
+                scc.push(w);
+            } while (w !== v);
+            const hasSelfLoop = (adj.get(v) || []).includes(v);
+            if (scc.length > 1 || hasSelfLoop) {
+                scc.reverse(); // restore discovery order (stack pops in reverse)
+                nonTrivialSccs.push(scc);
+                for (const key of scc) sccOf.set(key, scc);
+            }
         }
-        path.pop();
-        inStack.delete(key);
-        visited.add(key);
-    }
+    };
+
     for (const node of nodes) {
-        if (!visited.has(node.key)) dfs(node.key, [], new Set());
+        if (!nodeIndex.has(node.key)) strongconnect(node.key);
     }
-    return cycles;
+
+    // For each non-trivial SCC, extract one representative cycle path (start key repeated at end)
+    const cycles = [];
+    for (const scc of nonTrivialSccs) {
+        const sccSet = new Set(scc);
+        const sccAdj = new Map();
+        for (const v of scc) {
+            sccAdj.set(v, (adj.get(v) || []).filter((w) => sccSet.has(w)));
+        }
+        const start = scc[0];
+        const path = [];
+        const visited = new Set();
+        const findCycle = (v) => {
+            if (v === start && path.length > 0) {
+                cycles.push([...path, start]);
+                return true;
+            }
+            if (visited.has(v)) return false;
+            visited.add(v);
+            path.push(v);
+            for (const w of sccAdj.get(v) || []) {
+                if (findCycle(w)) return true;
+            }
+            path.pop();
+            return false;
+        };
+        findCycle(start);
+    }
+
+    return {cycles, sccOf};
 }
 
 /**
@@ -547,7 +600,7 @@ class DI {
             for (const dep of node.deps) {
                 if (dep.type !== 'injectable') continue;
                 if (!nodeKeySet.has(dep.key)) continue;
-                const edgeKey = `${node.key}→${dep.key}`;
+                const edgeKey = JSON.stringify([node.key, dep.key]);
                 if (edgeSeen.has(edgeKey)) continue;
                 edgeSeen.add(edgeKey);
                 edges.push({from: node.key, to: dep.key, isCircular: false});
@@ -555,13 +608,11 @@ class DI {
         }
 
         // Detect cycles then mark affected edges
-        const cycles = detectCycles(nodes, edges);
+        // An edge is circular iff both endpoints belong to the same non-trivial SCC.
+        const {cycles, sccOf} = detectCycles(nodes, edges);
         for (const edge of edges) {
-            edge.isCircular = cycles.some((cycle) =>
-                cycle.some(
-                    (k, i) => i < cycle.length - 1 && k === edge.from && cycle[i + 1] === edge.to,
-                ),
-            );
+            const fromScc = sccOf.get(edge.from);
+            edge.isCircular = fromScc !== undefined && fromScc === sccOf.get(edge.to);
         }
 
         return {nodes, edges, cycles};

--- a/src/mini-inject.js
+++ b/src/mini-inject.js
@@ -315,6 +315,8 @@ class DI {
     #bindings = new Map();
     /** @type {DI[]} */
     #subModules = [];
+    /** @type {DI | null} Parent DI instance when this is a fork */
+    #parent = null;
     /** @type {Set<string|Symbol>} Keys currently mid-resolution in this call-stack */
     #resolving = new Set();
     /** @type {Map<string|Symbol, {instance: any}>} Resolver refs for auto-detected cycle proxies */
@@ -386,6 +388,7 @@ class DI {
                 const subBinding = subModule.getBinding(injectable);
                 if (subBinding) return subBinding;
             }
+            if (this.#parent) return this.#parent.getBinding(injectable);
             return undefined;
         }
         return {
@@ -407,6 +410,11 @@ class DI {
             // First we try the subModules
             for (const subModule of this.#subModules) {
                 if (subModule.has(injectable)) return subModule.get(injectable);
+            }
+
+            // Then delegate to the parent (if this is a fork)
+            if (this.#parent && this.#parent.has(injectable)) {
+                return this.#parent.get(injectable);
             }
 
             /* *
@@ -632,6 +640,12 @@ class DI {
             this.#subModules.splice(index, 1);
         }
         return this;
+    }
+
+    fork() {
+        const child = new DI();
+        child.#parent = this;
+        return child;
     }
 
     #disposeInstance(instance) {

--- a/src/mini-inject.js
+++ b/src/mini-inject.js
@@ -607,7 +607,7 @@ class DI {
             return dep;
         })();
 
-        const {isSingleton = true, lateResolve = false} = opts || {};
+        const {isSingleton = true, lateResolve = false, eager = false} = opts || {};
         const key = resolveKey(token);
         if (this.#container.has(key)) this.#container.delete(key);
         this.#bindings.set(key, {
@@ -617,6 +617,7 @@ class DI {
             injectable,
             rawDeps: dependencies,
         });
+        if (eager && isSingleton) this.get(token);
         return this;
     }
 
@@ -633,10 +634,35 @@ class DI {
         return this;
     }
 
+    #disposeInstance(instance) {
+        if (instance && typeof instance.dispose === 'function') {
+            try {
+                instance.dispose();
+            } catch {
+                // ignore errors from dispose
+            }
+        }
+    }
+
+    unbind(injectable) {
+        const key = resolveKey(injectable);
+        if (this.#container.has(key)) {
+            this.#disposeInstance(this.#container.get(key));
+            this.#container.delete(key);
+        }
+        this.#bindings.delete(key);
+        return this;
+    }
+
     clear() {
         // Clear all sub-modules first
         for (const subModule of this.#subModules) {
             subModule.clear();
+        }
+
+        // Dispose all cached singleton instances
+        for (const instance of this.#container.values()) {
+            this.#disposeInstance(instance);
         }
 
         // Clear current instance containers

--- a/src/mini-inject.test.js
+++ b/src/mini-inject.test.js
@@ -1017,6 +1017,142 @@ test('Should clear empty containers without errors', (t) => {
 
 });
 
+// ─── unbind ───────────────────────────────────────────────────────────────────
+
+test('unbind should remove binding and prevent further resolution', (t) => {
+    const di = new DI();
+    di.bind(A, [di.literal(1)]);
+    t.true(di.has(A));
+    di.unbind(A);
+    t.false(di.has(A));
+    t.throws(() => di.get(A));
+});
+
+test('unbind should call dispose on cached singleton instance', (t) => {
+    const di = new DI();
+    let disposed = false;
+    class MyService {
+        dispose() {disposed = true;}
+    }
+    di.bind(MyService, []);
+    di.get(MyService); // populate cache
+    t.false(disposed);
+    di.unbind(MyService);
+    t.true(disposed);
+    t.false(di.has(MyService));
+});
+
+test('unbind should not call dispose on non-singleton (not cached)', (t) => {
+    const di = new DI();
+    let disposed = false;
+    class MyService {
+        dispose() {disposed = true;}
+    }
+    di.bind(MyService, [], {isSingleton: false});
+    di.get(MyService); // not cached
+    di.unbind(MyService);
+    t.false(disposed);
+    t.false(di.has(MyService));
+});
+
+test('unbind on unknown injectable should be a no-op', (t) => {
+    const di = new DI();
+    t.notThrows(() => di.unbind(A));
+});
+
+test('unbind should return this for chaining', (t) => {
+    const di = new DI();
+    di.bind(A, [di.literal(1)]);
+    t.is(di.unbind(A), di);
+});
+
+// ─── dispose on clear ─────────────────────────────────────────────────────────
+
+test('clear should call dispose on all cached singleton instances', (t) => {
+    const di = new DI();
+    const disposedLog = [];
+    class ServiceX {
+        constructor(id) {this.id = id;}
+        dispose() {disposedLog.push(this.id);}
+    }
+    di.bind('x1', () => new ServiceX('x1'));
+    di.bind('x2', () => new ServiceX('x2'));
+    di.get('x1');
+    di.get('x2');
+    di.clear();
+    t.deepEqual(disposedLog.sort(), ['x1', 'x2']);
+});
+
+test('clear should not throw when dispose throws', (t) => {
+    const di = new DI();
+    class BadService {
+        dispose() {throw new Error('dispose error');}
+    }
+    di.bind(BadService, []);
+    di.get(BadService);
+    t.notThrows(() => di.clear());
+});
+
+test('clear should call dispose on sub-module cached instances', (t) => {
+    const disposedLog = [];
+    class SubService {
+        dispose() {disposedLog.push('sub');}
+    }
+    const sub = new DI();
+    sub.bind(SubService, []);
+    sub.get(SubService);
+
+    const di = new DI();
+    di.subModule(sub);
+    di.clear();
+    t.deepEqual(disposedLog, ['sub']);
+});
+
+// ─── eager binding ────────────────────────────────────────────────────────────
+
+test('eager bind should instantiate singleton immediately', (t) => {
+    let created = false;
+    class EagerService {
+        constructor() {created = true;}
+    }
+    const di = new DI();
+    t.false(created);
+    di.bind(EagerService, [], {eager: true});
+    t.true(created);
+});
+
+test('eager bind should use same singleton instance on subsequent get', (t) => {
+    let count = 0;
+    class Counter {
+        constructor() {this.id = ++count;}
+    }
+    const di = new DI();
+    di.bind(Counter, [], {eager: true});
+    t.is(count, 1);
+    const c = di.get(Counter);
+    t.is(count, 1); // not created again
+    t.is(c.id, 1);
+});
+
+test('eager bind with isSingleton false should not instantiate', (t) => {
+    let created = false;
+    class EagerTransient {
+        constructor() {created = true;}
+    }
+    const di = new DI();
+    di.bind(EagerTransient, [], {isSingleton: false, eager: true});
+    t.false(created); // eager is ignored for transients
+});
+
+test('eager bind with factory function', (t) => {
+    let created = false;
+    const di = new DI();
+    di.bind('eagerKey', () => {created = true; return {done: true};}, {eager: true});
+    t.true(created);
+    const val = di.get('eagerKey');
+    t.is(val.done, true);
+});
+
 // ─── getDependencyGraph ───────────────────────────────────────────────────────
 
 test('getDependencyGraph: basic graph with no cycles', (t) => {

--- a/src/mini-inject.test.js
+++ b/src/mini-inject.test.js
@@ -1014,4 +1014,301 @@ test('Should clear empty containers without errors', (t) => {
     t.true(di.has('service'));
     const instance = di.get('service');
     t.is(instance.value, 'test');
+
+});
+
+// ─── getDependencyGraph ───────────────────────────────────────────────────────
+
+test('getDependencyGraph: basic graph with no cycles', (t) => {
+    class Svc1 {}
+    class Svc2 {}
+    class Svc3 {}
+
+    const di = new DI();
+    di.bind(Svc1, []);
+    di.bind(Svc2, []);
+    di.bind(Svc3, [Svc1, Svc2]);
+
+    const graph = di.getDependencyGraph();
+
+    t.is(graph.nodes.length, 3);
+    t.is(graph.edges.length, 2);
+    t.is(graph.cycles.length, 0);
+
+    const n1 = graph.nodes.find((n) => n.key === 'Svc1');
+    t.deepEqual(n1.deps, []);
+    t.true(n1.isSingleton);
+    t.false(n1.lateResolve);
+    t.false(n1.isSubModule);
+
+    const n3 = graph.nodes.find((n) => n.key === 'Svc3');
+    t.deepEqual(n3.deps, [
+        {type: 'injectable', key: 'Svc1'},
+        {type: 'injectable', key: 'Svc2'},
+    ]);
+
+    const edgeSvc3Svc1 = graph.edges.find((e) => e.from === 'Svc3' && e.to === 'Svc1');
+    t.truthy(edgeSvc3Svc1);
+    t.false(edgeSvc3Svc1.isCircular);
+});
+
+test('getDependencyGraph: custom factory is marked unknown deps', (t) => {
+    class SvcA {}
+
+    const di = new DI();
+    di.bind(SvcA, () => new SvcA());
+
+    const graph = di.getDependencyGraph();
+
+    t.is(graph.nodes.length, 1);
+    t.is(graph.nodes[0].deps, null);
+    t.is(graph.edges.length, 0);
+});
+
+test('getDependencyGraph: detects circular dependency and marks edges', (t) => {
+    class NodeA {}
+    class NodeB {}
+
+    const di = new DI();
+    di.bind(NodeA, [NodeB]);
+    di.bind(NodeB, [NodeA], {lateResolve: true});
+
+    const graph = di.getDependencyGraph();
+
+    t.is(graph.nodes.length, 2);
+    t.is(graph.cycles.length, 1);
+    t.deepEqual(graph.cycles[0], ['NodeA', 'NodeB', 'NodeA']);
+
+    const edgeAB = graph.edges.find((e) => e.from === 'NodeA' && e.to === 'NodeB');
+    t.true(edgeAB.isCircular);
+
+    const edgeBA = graph.edges.find((e) => e.from === 'NodeB' && e.to === 'NodeA');
+    t.true(edgeBA.isCircular);
+
+    const nodeB = graph.nodes.find((n) => n.key === 'NodeB');
+    t.true(nodeB.lateResolve);
+});
+
+test('getDependencyGraph: handles the A,B,C,D,E scenario', (t) => {
+    class SA {}
+    class SB {}
+    class SC {}
+    class SD {}
+    class SE {}
+
+    const di = new DI();
+    di.bind(SA, [SB]);
+    di.bind(SB, [SA], {lateResolve: true});
+    di.bind(SC, [SA, SB]);
+    di.bind(SD, [SA]);
+    di.bind(SE, [SD, SC, SB]);
+
+    const graph = di.getDependencyGraph();
+
+    t.is(graph.nodes.length, 5);
+    t.is(graph.cycles.length, 1);
+    t.deepEqual(graph.cycles[0], ['SA', 'SB', 'SA']);
+
+    // Non-circular edges
+    const edgeCtoA = graph.edges.find((e) => e.from === 'SC' && e.to === 'SA');
+    t.false(edgeCtoA.isCircular);
+
+    const edgeEtoD = graph.edges.find((e) => e.from === 'SE' && e.to === 'SD');
+    t.false(edgeEtoD.isCircular);
+
+    // Circular edges
+    const edgeAtoB = graph.edges.find((e) => e.from === 'SA' && e.to === 'SB');
+    t.true(edgeAtoB.isCircular);
+});
+
+test('getDependencyGraph: Token keys are displayed as Token<description>', (t) => {
+    class TokenSvc {}
+
+    const di = new DI();
+    const tok = DI.token(TokenSvc, 'myToken');
+    di.bind(tok, []);
+
+    const graph = di.getDependencyGraph();
+
+    t.is(graph.nodes.length, 1);
+    t.is(graph.nodes[0].key, 'Token<myToken>');
+});
+
+test('getDependencyGraph: literal and factory deps are described correctly', (t) => {
+    class SvcWithMixedDeps {}
+
+    function namedFactory() {
+        return 42;
+    }
+
+    const di = new DI();
+    di.bind(SvcWithMixedDeps, [DI.literal(true), DI.factory(namedFactory)]);
+
+    const graph = di.getDependencyGraph();
+    const node = graph.nodes[0];
+
+    t.deepEqual(node.deps, [
+        {type: 'literal', value: true},
+        {type: 'factory', name: 'namedFactory'},
+    ]);
+    // No edges since neither dep is an injectable node
+    t.is(graph.edges.length, 0);
+});
+
+test('getDependencyGraph: anonymous factory dep has name null', (t) => {
+    class SvcAnon {}
+
+    const di = new DI();
+    di.bind(SvcAnon, [DI.factory(() => 99)]);
+
+    const graph = di.getDependencyGraph();
+    const node = graph.nodes[0];
+
+    t.is(node.deps[0].type, 'factory');
+    t.is(node.deps[0].name, null);
+});
+
+test('getDependencyGraph: submodule bindings are marked isSubModule=true', (t) => {
+    class MainSvc {}
+    class SubSvc {}
+
+    const sub = new DI();
+    sub.bind(SubSvc, []);
+
+    const di = new DI();
+    di.bind(MainSvc, [SubSvc]);
+    di.subModule(sub);
+
+    const graph = di.getDependencyGraph();
+
+    t.is(graph.nodes.length, 2);
+
+    const mainNode = graph.nodes.find((n) => n.key === 'MainSvc');
+    t.false(mainNode.isSubModule);
+
+    const subNode = graph.nodes.find((n) => n.key === 'SubSvc');
+    t.true(subNode.isSubModule);
+
+    // Edge still present even though SubSvc is from a submodule
+    const edge = graph.edges.find((e) => e.from === 'MainSvc' && e.to === 'SubSvc');
+    t.truthy(edge);
+});
+
+test('getDependencyGraph: static method delegates to instance method', (t) => {
+    class SvcS {}
+
+    const di = new DI();
+    di.bind(SvcS, []);
+
+    const instanceGraph = di.getDependencyGraph();
+    const staticGraph = DI.getDependencyGraph(di);
+
+    t.deepEqual(instanceGraph, staticGraph);
+});
+
+test('getDependencyGraph: non-singleton bindings are marked correctly', (t) => {
+    class TransientSvc {}
+
+    const di = new DI();
+    di.bind(TransientSvc, [], {isSingleton: false});
+
+    const graph = di.getDependencyGraph();
+    const node = graph.nodes[0];
+
+    t.false(node.isSingleton);
+});
+
+// ─── formatDependencyGraph ────────────────────────────────────────────────────
+
+test('formatDependencyGraph: includes header by default', (t) => {
+    class HSvc {}
+
+    const di = new DI();
+    di.bind(HSvc, []);
+
+    const text = di.formatDependencyGraph();
+
+    t.true(text.includes('mini-inject dependency graph'));
+    t.true(text.includes('1 binding(s)'));
+    t.true(text.includes('0 cycle(s)'));
+});
+
+test('formatDependencyGraph: header can be disabled', (t) => {
+    class NoHSvc {}
+
+    const di = new DI();
+    di.bind(NoHSvc, []);
+
+    const text = di.formatDependencyGraph({header: false});
+
+    t.false(text.includes('mini-inject dependency graph'));
+});
+
+test('formatDependencyGraph: shows cycle warning on affected rows', (t) => {
+    class CycA {}
+    class CycB {}
+
+    const di = new DI();
+    di.bind(CycA, [CycB]);
+    di.bind(CycB, [CycA], {lateResolve: true});
+
+    const text = di.formatDependencyGraph();
+
+    t.true(text.includes('⚠ CYCLE:'));
+    t.true(text.includes('CycA → CycB → CycA'));
+    t.true(text.includes('Cycles detected:'));
+    t.true(text.includes('[1]'));
+});
+
+test('formatDependencyGraph: shows lateResolve tag', (t) => {
+    class LRA {}
+    class LRB {}
+
+    const di = new DI();
+    di.bind(LRA, [LRB]);
+    di.bind(LRB, [LRA], {lateResolve: true});
+
+    const text = di.formatDependencyGraph({header: false});
+
+    t.true(text.includes('lateResolve'));
+});
+
+test('formatDependencyGraph: marks custom factory as unknown deps', (t) => {
+    class CustomSvc {}
+
+    const di = new DI();
+    di.bind(CustomSvc, () => new CustomSvc());
+
+    const text = di.formatDependencyGraph({header: false});
+
+    t.true(text.includes('(custom initializer - unknown deps)'));
+});
+
+test('formatDependencyGraph: static method accepts pre-computed graph', (t) => {
+    class StaticFmtSvc {}
+
+    const di = new DI();
+    di.bind(StaticFmtSvc, []);
+
+    const graph = di.getDependencyGraph();
+    const text = DI.formatDependencyGraph(graph);
+
+    t.true(text.includes('StaticFmtSvc'));
+    t.true(text.includes('[singleton]'));
+});
+
+test('formatDependencyGraph: literal and factory deps are rendered in text', (t) => {
+    class MixedDepSvc {}
+
+    function buildValue() {
+        return 'x';
+    }
+
+    const di = new DI();
+    di.bind(MixedDepSvc, [DI.literal(42), DI.factory(buildValue)]);
+
+    const text = di.formatDependencyGraph({header: false});
+
+    t.true(text.includes('Literal<42>'));
+    t.true(text.includes('Factory<buildValue>'));
 });

--- a/src/mini-inject.test.js
+++ b/src/mini-inject.test.js
@@ -1153,6 +1153,148 @@ test('eager bind with factory function', (t) => {
     t.is(val.done, true);
 });
 
+// ─── fork ─────────────────────────────────────────────────────────────────────
+
+test('fork: parent bindings are visible in the fork', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(10)]);
+
+    const child = parent.fork();
+    const a = child.get(A);
+    t.truthy(a);
+    t.is(a.value, 10);
+});
+
+test('fork: parent singleton is reused in the fork (shared cache)', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(99)]);
+
+    const parentA = parent.get(A);
+    const child = parent.fork();
+    const childA = child.get(A);
+
+    t.is(parentA, childA); // same instance
+});
+
+test('fork: fork-local binding overrides parent for the fork only', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(1)]);
+
+    const child = parent.fork();
+    child.bind(A, [child.literal(42)]);
+
+    t.is(child.get(A).value, 42);  // fork's own
+    t.is(parent.get(A).value, 1);  // parent unchanged
+});
+
+test('fork: fork-local binding does not affect parent', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(1)]);
+
+    const child = parent.fork();
+    child.bind(B, [child.literal(5)]);
+
+    t.true(child.has(B));
+    t.false(parent.has(B)); // parent knows nothing about B
+});
+
+test('fork: factory in fork receives fork as di, can resolve parent bindings', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(5)]);
+
+    const child = parent.fork();
+    child.bind(C, (di) => new C(di.get(A), new B(2)));
+
+    const c = child.get(C);
+    t.is(c.a.value, 5);   // A resolved from parent through fork
+    t.is(c.b.value, 4);   // B(2) → value = 2 * 2 = 4
+});
+
+test('fork: clear() on fork does not affect parent', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(7)]);
+    const parentA = parent.get(A); // cache it
+
+    const child = parent.fork();
+    child.bind(B, [child.literal(3)]);
+    child.get(B);
+
+    child.clear();
+
+    t.false(child.has(B));           // fork-local binding gone
+    t.true(parent.has(A));           // parent unaffected
+    t.is(parent.get(A), parentA);   // parent singleton still intact
+});
+
+test('fork: clear() on fork, fork can still delegate to parent after clear', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(3)]);
+
+    const child = parent.fork();
+    child.bind(B, [child.literal(1)]);
+    child.clear();
+
+    // After clear, fork still knows its parent
+    const a = child.get(A);
+    t.is(a.value, 3);
+});
+
+test('fork: has() returns true for parent bindings', (t) => {
+    const parent = new DI();
+    parent.bind(A, [parent.literal(1)]);
+
+    const child = parent.fork();
+    t.true(child.has(A));
+});
+
+test('fork: fallback works when neither fork nor parent have a binding', (t) => {
+    const parent = new DI();
+    const child = parent.fork();
+
+    const result = child.get(D, 'fallback');
+    t.is(result, 'fallback');
+});
+
+test('fork: fork of a fork (multi-level scoping)', (t) => {
+    const root = new DI();
+    root.bind(A, [root.literal(1)]);
+
+    const mid = root.fork();
+    mid.bind(B, [mid.literal(2)]);
+
+    const leaf = mid.fork();
+    leaf.bind(C, (di) => new C(di.get(A), di.get(B)));
+
+    const c = leaf.get(C);
+    t.is(c.a.value, 1); // from root
+    t.is(c.b.value, 4); // from mid: B(2) → value = 2*2 = 4
+});
+
+test('fork: dispose is called on fork-local singletons only on clear', (t) => {
+    const disposedLog = [];
+    class Resource {
+        constructor(name) {
+            this.name = name;
+        }
+        dispose() {
+            disposedLog.push(this.name);
+        }
+    }
+
+    const parent = new DI();
+    parent.bind('root-res', () => new Resource('root'));
+    parent.get('root-res'); // cache in parent
+
+    const child = parent.fork();
+    child.bind('fork-res', () => new Resource('fork'));
+    child.get('fork-res'); // cache in fork
+
+    child.clear();
+
+    t.deepEqual(disposedLog, ['fork']); // only fork-local disposed
+    t.is(parent.get('root-res').name, 'root'); // parent's instance still alive
+});
+
 // ─── getDependencyGraph ───────────────────────────────────────────────────────
 
 test('getDependencyGraph: basic graph with no cycles', (t) => {


### PR DESCRIPTION
## Summary

v1.12.0 adds five independent features: scoped container forking, explicit unbind, eager singleton instantiation, a `dispose()` lifecycle hook on cleanup, and a full dependency graph analyzer with a CLI.

---

## What's new

### `di.fork()` — scoped child containers

Creates a child `DI` instance that delegates any unresolved key upward to its parent. Parent singletons are **shared** (same cached instance), fork-local bindings stay isolated, and `clear()` on a fork never touches the parent. Forks can be chained for multi-level scoping.

Primary use cases: per-request scoping in servers and per-test overrides without rebuilding the full container.

```js
const appDI = new DI();
appDI.bind(DbPool, []);
appDI.bind(UserRepo, [DbPool]);

// per HTTP request:
const reqDI = appDI.fork();
reqDI.bind(RequestContext, () => new RequestContext(req));
reqDI.bind(OrderService, [UserRepo, RequestContext]);

const svc = reqDI.get(OrderService); // UserRepo resolved from parent (shared)
reqDI.clear(); // disposes fork-local singletons only; appDI untouched
```

### `di.unbind(injectable)` — remove a single binding

Removes a binding and its cached singleton from the container. If the cached instance exposes a `dispose()` method, it is called before removal. Errors from `dispose()` are silently ignored. Returns `this` for chaining.

### `{ eager: true }` option on `bind()`

When set on a singleton binding, the instance is created immediately at bind time rather than lazily on first `get()`. Silently ignored for transient bindings.

```js
di.bind(CacheService, [DbPool], { eager: true }); // instantiated right away
```

### `dispose()` lifecycle on `clear()`

`clear()` now calls `dispose()` on every cached singleton instance (and recursively on sub-module instances) before wiping the container. Errors from `dispose()` are silently ignored.

### `getDependencyGraph()` / `DI.getDependencyGraph(di)`

Returns a serialisable graph object:
```js
{
  nodes: [{ key, isSingleton, lateResolve, isSubModule, deps }],
  edges: [{ from, to, isCircular }],
  cycles: [["A", "B", "A"]]
}
```

Each `deps` entry is a typed descriptor — `injectable`, `Literal<value>`, or `Factory<name>` — so no dependency is truly "unknown". Bindings declared with a custom factory function have `deps: null`. Sub-module bindings are included and flagged with `isSubModule: true`. Token keys are rendered as `Token<description>`.

### `formatDependencyGraph(opts?)` / `DI.formatDependencyGraph(graph, opts?)`

Renders a human-readable text report. Pass `{ header: false }` to suppress the title and cycles-summary section.

```
mini-inject dependency graph — 2 binding(s), 1 cycle(s)
══════════════════════════════════════════════════════

A   [singleton]               B  ⚠ CYCLE: A → B → A
B   [singleton]  lateResolve  A  ⚠ CYCLE: A → B → A

Cycles detected:
  [1] A → B → A
```

### `bin/analyze.mjs` — CLI

```bash
npx mini-inject analyze <file>                  # text report (default)
npx mini-inject analyze <file> --format=json    # JSON output
npx mini-inject analyze <file> --no-header      # rows only, no title
npx mini-inject analyze <file> --export=appDI   # pick a named export
```

Auto-discovers `DI` instances from `default` export, named exports, or properties of `module.exports`.

---

## Files changed

| File | Change |
|---|---|
| `src/mini-inject.js` | `fork()`, `unbind()`, `#disposeInstance()`, `eager` support, `rawDeps` in binding record, graph helpers, 4 new `DI` methods |
| `src/mini-inject.d.ts` | `fork()`, `unbind()`, `eager` on all `bind()` overloads, `DepDescriptor`, `GraphNode`, `GraphEdge`, `DependencyGraph`, `FormatGraphOptions` types + method signatures |
| `src/mini-inject.test.js` | 154 tests total: 5 unbind, 3 dispose-on-clear, 4 eager, 11 fork, 19 graph/format |
| `bin/analyze.mjs` | New CLI script |
| `package.json` | Version → `1.12.0`, `bin` field, `bin/` added to `files` |
| `README.md` | New *Forking* section, new *Dependency Graph Analyzer* section, changelog entry |

## No new runtime dependencies

Zero external dependencies added. The CLI uses only Node built-ins (`url`, `path`).