### PR TITLE
fix: prevent di.clear() from eagerly instantiating uninitialized proxies (v1.13.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,16 @@ npx mini-inject analyze ./src/container.js --export=appDI
 
 ## Changelog
 
+#### 1.13.2
+
+* Fixed a critical bug in `di.clear()` where uninitialized Proxy instances (from `lateResolve: true`) were being eagerly instantiated just to check for a `dispose` method. Now, uninitialized proxies are correctly bypassed during clear.
+
+#### 1.13.1
+
+* Fixed `di.has()` and `di.getBinding()` not working for Container bindings.
+* Fixed TypeScript overload resolution for `di.get()` when passing a Container. It now correctly infers `T[]` return type.
+* Fixed the `get()` fallback behavior for Containers; it now correctly returns an empty array `[]` when `fallbackToEmptyList` is truthy and the container has no bindings, instead of returning `true`.
+
 #### 1.13.0
 
 * Added `Container` class — allows binding multiple injectables, factories, or tokens to a single container reference. When resolved, the container returns an array containing all resolved items.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-inject",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Minimalistic dependency injection implementation",
   "type": "commonjs",
   "main": "index.js",

--- a/src/mini-inject.js
+++ b/src/mini-inject.js
@@ -20,6 +20,10 @@ function resolveKey(injectable) {
     return new String(injectable);
 }
 
+const IS_DI_PROXY = Symbol('IS_DI_PROXY');
+const HAS_DI_PROXY_INSTANCE = Symbol('HAS_DI_PROXY_INSTANCE');
+const GET_DI_PROXY_INSTANCE = Symbol('GET_DI_PROXY_INSTANCE');
+
 class Token {
     #injectable;
     #description;
@@ -91,12 +95,18 @@ class DIProxyBuilder {
 
     build() {
         const getInstance = () => this.#getInstance();
+        const hasInstance = () => this.#hasInstance;
+        const getRawInstance = () => this.#__instance;
         const className = this.#targetClass?.name || "Object";
         const shell = this.#targetClass?.prototype
             ? Object.create(this.#targetClass.prototype)
             : {};
         const handler = {
             get(target, prop, receiver) {
+                if (prop === IS_DI_PROXY) return true;
+                if (prop === HAS_DI_PROXY_INSTANCE) return hasInstance();
+                if (prop === GET_DI_PROXY_INSTANCE) return getRawInstance();
+
                 if (prop === Symbol.toStringTag) {
                     return className;
                 }
@@ -834,6 +844,13 @@ class DI {
     }
 
     #disposeInstance(instance) {
+        if (!instance) return;
+
+        if (instance[IS_DI_PROXY]) {
+            if (!instance[HAS_DI_PROXY_INSTANCE]) return;
+            instance = instance[GET_DI_PROXY_INSTANCE];
+        }
+
         if (instance && typeof instance.dispose === 'function') {
             try {
                 instance.dispose();

--- a/src/mini-inject.test.js
+++ b/src/mini-inject.test.js
@@ -1670,11 +1670,33 @@ test('Container: has and getBinding work correctly', (t) => {
     di.bind(plugins, PluginA);
 
     t.is(di.has(plugins), true);
-    
+
     const bindings = di.getBinding(plugins);
     t.true(Array.isArray(bindings));
     t.is(bindings.length, 1);
     t.is(typeof bindings[0].resolveFunction, 'function');
     t.is(bindings[0].isSingleton, true);
     t.is(bindings[0].lateResolve, false);
+});
+
+test('Should not instantiate uninitialized proxies during clear', (t) => {
+    let initialized = false;
+    class B {}
+    class LazyService {
+        constructor(b) {
+            initialized = true;
+        }
+        dispose() {}
+    }
+
+    const di = new DI();
+    di.bind(B, []);
+    di.bind(LazyService, [B], {lateResolve: true, isSingleton: true});
+
+    const proxyInstance = di.get(LazyService);
+    t.is(initialized, false, 'Should not be initialized yet');
+
+    di.clear();
+
+    t.is(initialized, false, 'Should not be initialized during clear');
 });


### PR DESCRIPTION
This PR addresses a critical bug in the container teardown logic where di.clear() was inadvertently forcing lazy bindings (lateResolve: true) to be fully instantiated just to check if they needed to be disposed.

Bug Fix
* Safe Proxy Disposal: Previously, the #disposeInstance() internal method checked typeof instance.dispose === 'function', which triggered the get trap on DIProxyBuilder proxies, effectively instantiating the lazy service.
* Internal Proxy Introspection: Introduced internal backdoor symbols (IS_DI_PROXY, HAS_DI_PROXY_INSTANCE, GET_DI_PROXY_INSTANCE) to the proxy handler. This allows #disposeInstance() to securely inspect proxies and determine if they are instantiated without triggering their get traps.
* Uninitialized proxies are now safely bypassed during clear() operations.