### PR TITLE
ci: add Node.js CI workflow and support 'no bump' label

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,37 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        run: npm run build
+
+      - name: Run validation
+        run: npm run validate
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,20 +31,6 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run validation and tests
-        run: |
-          npm run build
-          npm run validate
-          npm test
-
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       - name: Determine version bump type
         id: bump_type
         run: |
@@ -52,13 +38,20 @@ jobs:
           TITLE='${{ github.event.pull_request.title }}'
           BUMP=""
           
-          # Check labels first (case-insensitive)
-          if echo "$LABELS" | grep -qi '"name":\s*"major"'; then
-            BUMP="major"
-          elif echo "$LABELS" | grep -qi '"name":\s*"minor"'; then
-            BUMP="minor"
-          elif echo "$LABELS" | grep -qi -E '"name":\s*"(patch|fix|bug)"'; then
-            BUMP="patch"
+          # Check for explicit "no bump" label first
+          if echo "$LABELS" | grep -qi '"name":\s*"no bump"'; then
+            BUMP="none"
+          fi
+          
+          # Check other labels if "no bump" is not set
+          if [ -z "$BUMP" ]; then
+            if echo "$LABELS" | grep -qi '"name":\s*"major"'; then
+              BUMP="major"
+            elif echo "$LABELS" | grep -qi '"name":\s*"minor"'; then
+              BUMP="minor"
+            elif echo "$LABELS" | grep -qi -E '"name":\s*"(patch|fix|bug)"'; then
+              BUMP="patch"
+            fi
           fi
           
           # Fallback to Conventional Commits parsing from PR title
@@ -82,14 +75,34 @@ jobs:
           echo "bump=$BUMP" >> $GITHUB_OUTPUT
           echo "Version bump type determined: $BUMP"
 
+      - name: Install dependencies
+        if: steps.bump_type.outputs.bump != 'none'
+        run: npm ci
+
+      - name: Run validation and tests
+        if: steps.bump_type.outputs.bump != 'none'
+        run: |
+          npm run build
+          npm run validate
+          npm test
+
+      - name: Configure Git
+        if: steps.bump_type.outputs.bump != 'none'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Bump version
+        if: steps.bump_type.outputs.bump != 'none'
         run: |
           npm version ${{ steps.bump_type.outputs.bump }} -m "chore: bump version to %s [skip ci]"
 
       - name: Push version bump
+        if: steps.bump_type.outputs.bump != 'none'
         run: |
           git push origin main --follow-tags
 
       - name: Publish to npm
+        if: steps.bump_type.outputs.bump != 'none'
         run: |
           npm publish --provenance

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "commonjs",
   "main": "index.js",
   "module": "index.mjs",
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "bin": {
     "mini-inject": "./bin/analyze.mjs"
   },


### PR DESCRIPTION
This PR adds the Node.js CI workflow to support testing across Node versions 18, 20, and 22 (enabling the badge on the README). It also updates the NPM publish workflow to support the "no bump" label for skipping version bumps on non-code changes, and updates the package engines requirement.