### PR TITLE
chore: release 1.13.6 with online documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The goal is to offer dependency injection as complete as possible with the most 
 
 Everything runs synchronously and no need to add a bunch of decorators everywhere. It works as intended and there is no black-box or magic
 
+Please refer to the [documentation](https://fernando7jr.github.io/mini-inject/) or follow this readme.
+
 ## Installation
 
 MiniInject is available as the [package mini-inject](https://www.npmjs.com/package/mini-inject).
@@ -658,6 +660,10 @@ npx mini-inject analyze ./src/container.js --export=appDI
 ```
 
 ## Changelog
+
+#### 1.13.5 and 1.13.6
+
+* Published the documentation online
 
 #### 1.13.4
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "bugs": {
     "url": "https://github.com/fernando7jr/mini-inject/issues"
   },
-  "homepage": "https://github.com/fernando7jr/mini-inject#readme",
+  "homepage": "https://fernando7jr.github.io/mini-inject/",
   "ava": {
     "files": [
       "test/**/*"

--- a/src/docs/05-changelog.md
+++ b/src/docs/05-changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### 1.13.5 and 1.13.6
+
+* Published the documentation online
+
 #### 1.13.4
 * Added SECURITY.md
 * Included github actions


### PR DESCRIPTION
This PR updates the package's homepage and README to point to the newly configured GitHub Pages documentation:

1. **Homepage**: Pointed `homepage` in `package.json` to the online docs at `https://fernando7jr.github.io/mini-inject/`.
2. **README.md**: Added a direct link to the online documentation page.
3. **Changelog**: Added a release entry for 1.13.5/1.13.6 documenting the online publication.

This release will trigger the documentation deployment to GitHub Pages.